### PR TITLE
Fix redirect path in Message controller

### DIFF
--- a/SocialMedia.Web/Controllers/MessageController.cs
+++ b/SocialMedia.Web/Controllers/MessageController.cs
@@ -111,7 +111,7 @@ namespace SocialMedia.Web.Controllers
 
             await _messageService.AddMessage(message);
 
-            return RedirectToAction("Index", "Messages");
+            return RedirectToAction("Index", "Message");
 
         }
     }


### PR DESCRIPTION
## Summary
- correct redirect in `MessageController` to use the `Message` controller

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684d16555920832fb35c02c38520ab16