### PR TITLE
Fix year formatting check in GetTimeFormat

### DIFF
--- a/SocialMedia.Model/Post.cs
+++ b/SocialMedia.Model/Post.cs
@@ -50,7 +50,7 @@ namespace SocialMedia.Model
             {
                 return time.Days + " days";
             }
-            else if(new TimeSpan(365,0,0) < time )
+            else if(TimeSpan.FromDays(365) <= time )
             {
                 return (time.Days / 365) + " years";
             }


### PR DESCRIPTION
## Summary
- update `new TimeSpan(365,0,0)` check to use `TimeSpan.FromDays(365)`
- format times >= 365 days as years

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d184e7d64832f9789b572d9b201ea