### PR TITLE
Fix UpdateFriend matching and add tests

### DIFF
--- a/SocialMedia.Application/Friend/FriendService.cs
+++ b/SocialMedia.Application/Friend/FriendService.cs
@@ -118,13 +118,11 @@ namespace SocialMedia.Application.Friend
             try
             {
                 var friendModel = await _dbContext.Friend
-                    .SingleAsync(c => c.ToUserId == friend.ToUserId && c.FromUserId == friend.FromUserId && c.Status == friend.Status);
+                    .SingleOrDefaultAsync(c => c.ToUserId == friend.ToUserId && c.FromUserId == friend.FromUserId);
 
                 if (friendModel != null)
                 {
                     friendModel.Status = friend.Status;
-                    friendModel.ToUserId = friend.ToUserId;
-                    friendModel.FromUserId = friend.FromUserId;
                 }
                 else
                 {

--- a/SocialMedia.Tests/FriendServiceTests/UpdateFriendTests.cs
+++ b/SocialMedia.Tests/FriendServiceTests/UpdateFriendTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using SocialMedia.Application.Friend;
+using SocialMedia.Data;
+using SocialMedia.Model;
+using SocialMedia.Model.Enums;
+using Xunit;
+
+namespace SocialMedia.Tests.FriendServiceTests
+{
+    public class UpdateFriendTests
+    {
+        private SocialMediaDbContext GetContext()
+        {
+            var options = new DbContextOptionsBuilder<SocialMediaDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new SocialMediaDbContext(options);
+        }
+
+        [Fact]
+        public async void UpdateFriend_ChangesStatus()
+        {
+            using var context = GetContext();
+            var service = new FriendService(context);
+
+            var friend = new Friend { FromUserId = 1, ToUserId = 2, Status = FriendStatus.Pending };
+            context.Add(friend);
+            context.SaveChanges();
+
+            friend.Status = FriendStatus.Accepted;
+            var result = await service.UpdateFriend(friend);
+
+            var updated = context.Friend.Single();
+            Assert.True(result);
+            Assert.Equal(FriendStatus.Accepted, updated.Status);
+        }
+    }
+}

--- a/SocialMedia.Tests/SocialMedia.Tests.csproj
+++ b/SocialMedia.Tests/SocialMedia.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.11" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SocialMedia.Application\SocialMedia.Application.csproj" />
+    <ProjectReference Include="..\SocialMedia.Data\SocialMedia.Data.csproj" />
+    <ProjectReference Include="..\SocialMedia.Model\SocialMedia.Model.csproj" />
+  </ItemGroup>
+</Project>

--- a/SocialMedia.sln
+++ b/SocialMedia.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SocialMedia.Application", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocialMedia.Helper", "SocialMedia.Helper\SocialMedia.Helper.csproj", "{8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SocialMedia.Tests", "SocialMedia.Tests\SocialMedia.Tests.csproj", "{6AFDA9D2-8290-402C-ABF8-C98B9E1AA849}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,11 +46,15 @@ Global
 		{AF96AD3C-03B5-4476-9220-5067B0B42358}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF96AD3C-03B5-4476-9220-5067B0B42358}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF96AD3C-03B5-4476-9220-5067B0B42358}.Release|Any CPU.Build.0 = Release|Any CPU
-		{8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {8171145D-0F57-4F84-9E53-C8BBB7D5ACE6}.Release|Any CPU.Build.0 = Release|Any CPU
+                {6AFDA9D2-8290-402C-ABF8-C98B9E1AA849}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {6AFDA9D2-8290-402C-ABF8-C98B9E1AA849}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {6AFDA9D2-8290-402C-ABF8-C98B9E1AA849}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {6AFDA9D2-8290-402C-ABF8-C98B9E1AA849}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- update `UpdateFriend` query to match only by user IDs
- don't overwrite user IDs when updating
- add xUnit test project with a status transition test

## Testing
- `dotnet test SocialMedia.sln` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d19436828832f95024fcef9a5771f